### PR TITLE
Add config to enable debug specific logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ end
 
 Pass a string to `Parsy.main()`. Here is an example:
 
-```
+```elixir
 iex> Parsy.main("let's parse some syllables!")
 
 process #PID<0.228.0>: syllabifying "{#PID<0.231.0>, #Reference<0.1896839920.1939079179.3341>}"
@@ -34,7 +34,7 @@ Every time `Parsy` spawns a new process, it will print the associated PID and re
 
 Once the computation completes, `Parsy` returns a map:
 
-```
+```elixir
 %{
   complex: [["syllables", 3]],
   complex_count: 1,
@@ -42,3 +42,11 @@ Once the computation completes, `Parsy` returns a map:
   words: [{"lets", 1}, {"parse", 1}, {"some", 1}, {"syllables", 3}]
 }
 ```
+
+## Configuration
+
+If you are facing an issue with Parsy, you can enable `debug` mode to log extra events. You can do this by setting the following config in either config.exs or environment specific config files i.e. prod.exs, dev.exs or test.exs.
+```elixir
+:parsy, :debug, true
+```
+The events will be logged at the debug level, so make sure your logger is configured for the same.

--- a/lib/parsy/logger.ex
+++ b/lib/parsy/logger.ex
@@ -1,0 +1,19 @@
+defmodule Parsy.Logger do
+  @moduledoc """
+  The custom logger for Parsy.
+  """
+
+  require Logger
+
+  @doc """
+  The basic log function. It logs to debug level if config is enabled.
+  """
+  @spec log(binary) :: :ok
+  def log(message) do
+    if Application.get_env(:parsy, :debug) do
+      Logger.debug(message)
+    end
+
+    :ok
+  end
+end

--- a/lib/parsy/worker.ex
+++ b/lib/parsy/worker.ex
@@ -11,7 +11,7 @@ defmodule Parsy.Worker do
   end
 
   def handle_call({:syllabify, chunk_of_words}, from, state) do
-    IO.puts("process #{inspect(self())}: syllabifying \"#{inspect(from)}\"")
+    Parsy.Logger.log("process #{inspect(self())}: syllabifying \"#{inspect(from)}\"")
     {:reply, Parsy.Engine.syllabify(chunk_of_words), state}
   end
 end


### PR DESCRIPTION
* Add a custom logger to use the config to decide whether to log or not.
* Move IO.puts in worker to instead use the new custom logger.